### PR TITLE
Add priority support to automapper_plus.configurator tag

### DIFF
--- a/DependencyInjection/Compiler/ConfigurationLoaderPass.php
+++ b/DependencyInjection/Compiler/ConfigurationLoaderPass.php
@@ -3,6 +3,7 @@
 namespace AutoMapperPlus\AutoMapperPlusBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\PriorityTaggedServiceTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
@@ -13,15 +14,17 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class ConfigurationLoaderPass implements CompilerPassInterface
 {
+    use PriorityTaggedServiceTrait;
+
     /**
      * @inheritdoc
      */
     public function process(ContainerBuilder $container)
     {
         $mapperFactory = $container->getDefinition('automapper_plus.mapper_factory');
-        $configurators = $container->findTaggedServiceIds('automapper_plus.configurator');
-        foreach ($configurators as $id => $_) {
-            $mapperFactory->addMethodCall('addConfigureCallback', [new Reference($id)]);
+        $configurators = $this->findAndSortTaggedServices('automapper_plus.configurator', $container);
+        foreach ($configurators as $configurator) {
+            $mapperFactory->addMethodCall('addConfigureCallback', [$configurator]);
         }
     }
 }


### PR DESCRIPTION
Add support for `priority` tag to use like this:

```yaml
App\Mapping\MappingConfig:
        tags:
            - { name: automapper_plus.configurator, priority: -512 }
```