### PR TITLE
Root node fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+language: php
+php:
+  - 7.0
+  - 7.1
+  - 7.2
+  - 7.3
+  - 7.4snapshot
+cache:
+  directories:
+    - $HOME/.composer/cache/files
+
+before_install:
+  - composer self-update
+
+install:
+  - composer update --no-interaction --prefer-dist --prefer-stable
+
+script:
+  - ./vendor/bin/phpunit tests/*
+
+jobs:
+  include:
+    - stage: Test
+      php: 7.0
+      name: prefer-lowest
+      install:
+        - composer update --no-interaction --prefer-dist --prefer-stable --prefer-lowest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: php
 php:
-  - 7.0
   - 7.1
   - 7.2
   - 7.3
@@ -21,7 +20,7 @@ script:
 jobs:
   include:
     - stage: Test
-      php: 7.0
+      php: 7.1
       name: prefer-lowest
       install:
         - composer update --no-interaction --prefer-dist --prefer-stable --prefer-lowest

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -2,6 +2,7 @@
 
 namespace AutoMapperPlus\AutoMapperPlusBundle\DependencyInjection;
 
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -9,8 +10,11 @@ class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('auto_mapper_plus');
+        $treeBuilder = new TreeBuilder('auto_mapper_plus');
+        /** @var ArrayNodeDefinition $rootNode */
+        $rootNode = \method_exists(TreeBuilder::class, 'getRootNode')
+            ? $treeBuilder->getRootNode()
+            : $treeBuilder->root('auto_mapper_plus');
 
         $rootNode
             ->children()

--- a/composer.json
+++ b/composer.json
@@ -19,5 +19,9 @@
         "php": ">=7.0.0",
         "symfony/framework-bundle": "^3.3|^4.0",
         "mark-gerarts/auto-mapper-plus": "^1.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^6.5|^8.0",
+        "symfony/phpunit-bridge": "^3.4|^4.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,9 @@
        }
     },
     "require": {
-        "php": ">=7.0.0",
+        "php": ">=7.1.0",
         "symfony/framework-bundle": "^3.3|^4.0",
-        "mark-gerarts/auto-mapper-plus": "^1.0"
+        "mark-gerarts/auto-mapper-plus": "^1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.5|^8.0",

--- a/tests/TestConfiguration.php
+++ b/tests/TestConfiguration.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace AutoMapperPlus\AutoMapperPlusBundle\test;
+
+
+use AutoMapperPlus\AutoMapperPlusBundle\DependencyInjection\Configuration;
+use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+
+class TestConfiguration extends TestCase
+{
+
+    public function testGetConfiguration() {
+
+        $configuration = new Configuration();
+
+        $this->assertInstanceOf(TreeBuilder::class, $configuration->getConfigTreeBuilder());
+
+    }
+
+}


### PR DESCRIPTION
Solves deprecation fired for Treebuilder (root method deprecated since Symfony 4.3)
The solution is to pass the root name to the constructor instead.

I've set up a little test to fire up those deprecations:

https://travis-ci.com/gianiaz/automapper-plus-bundle/builds/132166442

Then I did the fix and this is the green pipeline:

https://travis-ci.com/gianiaz/automapper-plus-bundle/builds/132167244
