### PR TITLE
Add GitHub Action Tests

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -1,0 +1,73 @@
+name: CI
+
+on:
+    push:
+    pull_request:
+
+jobs:
+    phpunit:
+        runs-on: ubuntu-20.04
+        strategy:
+            matrix:
+                include:
+                    -   php: '7.2'
+                        phpunit: '8.5'
+                        symfony: '4.4.*'
+                    -   php: '7.2'
+                        phpunit: '8.5'
+                        symfony: '5.4.*'
+                    -   php: '7.3'
+                        phpunit: '9.5'
+                        symfony: '4.4.*'
+                    -   php: '7.3'
+                        phpunit: '9.5'
+                        symfony: '5.4.*'
+                    -   php: '7.4'
+                        phpunit: '9.5'
+                        symfony: '4.4.*'
+                    -   php: '7.4'
+                        phpunit: '9.5'
+                        symfony: '5.4.*'
+                    -   php: '8.0'
+                        phpunit: '9.5'
+                        symfony: '4.4.*'
+                    -   php: '8.0'
+                        phpunit: '9.5'
+                        symfony: '5.4.*'
+                    -   php: '8.0'
+                        phpunit: '9.5'
+                        symfony: '6.0.*'
+                    -   php: '8.1'
+                        phpunit: '9.5'
+                        symfony: '4.4.*'
+                    -   php: '8.1'
+                        phpunit: '9.5'
+                        symfony: '5.4.*'
+                    -   php: '8.1'
+                        phpunit: '9.5'
+                        symfony: '6.0.*'
+        steps:
+            -   uses: actions/checkout@v2
+
+            -   name: Install PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: ${{ matrix.php }}
+                    tools: 'composer:v2,flex'
+
+            -   name: Cache Composer dependencies
+                uses: actions/cache@v2
+                with:
+                    path: '~/.composer/cache'
+                    key: ${{ runner.os }}-php${{ matrix.php }}-phpunit${{ matrix.phpunit }}-symfony${{ matrix.symfony }}-${{ hashFiles('**/composer.json') }}
+
+            -   name: Install dependencies with composer
+                env:
+                    SYMFONY_REQUIRE: ${{ matrix.symfony }}
+                run: composer update --no-interaction --no-progress
+
+            -   name: Run test suite
+                uses: php-actions/phpunit@v3
+                with:
+                    php_version: ${{ matrix.php }}
+                    version: ${{ matrix.phpunit }}


### PR DESCRIPTION
I've try out the GitHub actions with this bundle a little bit because I missed CI for this repository 🙃 

It's now testing the different PHP versions from 7.2 to 8.1 and the different symfony versions 4.4, 5.4 and 6.0 which are supported by the bundle.

See the finished GitHub action job https://github.com/malteschlueter/automapper-plus-bundle/actions/runs/1794381797

WDYT?