### PR TITLE
Added missing return type to AutoMapperPlusBundle::build() to fix deprecation

### DIFF
--- a/AutoMapperPlusBundle.php
+++ b/AutoMapperPlusBundle.php
@@ -16,7 +16,7 @@ class AutoMapperPlusBundle extends Bundle
     /**
      * @inheritdoc
      */
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
         $container->addCompilerPass(new ConfigurationLoaderPass());


### PR DESCRIPTION
fixed this issue:
https://github.com/mark-gerarts/automapper-plus-bundle/issues/28 